### PR TITLE
[RFR] Change Trailing Comma Policy

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,7 @@
             {
                 "singleQuote": true,
                 "tabWidth": 4,
-                "trailingComma": "all"
+                "trailingComma": "es5"
             }
         ],
         "import/no-extraneous-dependencies": "off",

--- a/src/graphQLClientServer.js
+++ b/src/graphQLClientServer.js
@@ -56,7 +56,7 @@ export default function(data, url = 'http://localhost:3000/graphql') {
             query.query,
             undefined,
             undefined,
-            query.variables,
+            query.variables
         ).then(
             result => {
                 const body = JSON.stringify(result);
@@ -66,7 +66,7 @@ export default function(data, url = 'http://localhost:3000/graphql') {
             error => {
                 req.setResponseHeader('Content-Type', 'application/json');
                 req.receive(500, JSON.stringify(error));
-            },
+            }
         );
     });
 

--- a/src/introspection/DateType.js
+++ b/src/introspection/DateType.js
@@ -18,7 +18,7 @@ export default new GraphQLScalarType({
         if (ast.kind !== Kind.STRING) {
             throw new GraphQLError(
                 `Query error: Can only parse dates strings, got a: ${ast.kind}`,
-                [ast],
+                [ast]
             );
         }
         if (isNaN(Date.parse(ast.value))) {

--- a/src/introspection/getFieldsFromEntities.js
+++ b/src/introspection/getFieldsFromEntities.js
@@ -36,7 +36,7 @@ export default (entities, checkRequired = true) => {
                 fieldValues[fieldName],
                 checkRequired
                     ? fieldValues[fieldName].length === nbValues
-                    : false,
+                    : false
             ),
         };
         return fields;

--- a/src/introspection/getFieldsFromEntities.spec.js
+++ b/src/introspection/getFieldsFromEntities.spec.js
@@ -7,7 +7,7 @@ test('does infer field types', () => {
             { id: 1, foo: 'foo1' },
             { id: 2, foo: 'foo2', bar: 'bar1' },
             { id: 3, bar: 'bar2' },
-        ]),
+        ])
     ).toEqual({
         id: { type: new GraphQLNonNull(GraphQLID) },
         foo: { type: GraphQLString },

--- a/src/introspection/getFilterTypesFromData.js
+++ b/src/introspection/getFilterTypesFromData.js
@@ -15,7 +15,7 @@ const getRangeFiltersFromEntities = entities => {
         const fieldType = getTypeFromValues(
             fieldName,
             fieldValues[fieldName],
-            false,
+            false
         );
         if (
             fieldType == GraphQLInt ||
@@ -98,9 +98,9 @@ export default data =>
                             q: { type: GraphQLString },
                         },
                         getFieldsFromEntities(data[key], false),
-                        getRangeFiltersFromEntities(data[key]),
+                        getRangeFiltersFromEntities(data[key])
                     ),
                 }),
             }),
-        {},
+        {}
     );

--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -128,7 +128,7 @@ export default data => {
         fields: types.reduce((fields, type) => {
             const typeFields = typesByName[type.name].getFields();
             const nullableTypeFields = Object.keys(
-                typeFields,
+                typeFields
             ).reduce((f, fieldName) => {
                 f[fieldName] = Object.assign({}, typeFields[fieldName], {
                     type:

--- a/src/introspection/getSchemaFromData.spec.js
+++ b/src/introspection/getSchemaFromData.spec.js
@@ -107,11 +107,11 @@ test('creates one type per data type', () => {
     const typeMap = getSchemaFromData(data).getTypeMap();
     expect(typeMap['Post'].name).toEqual(PostType.name);
     expect(Object.keys(typeMap['Post'].getFields())).toEqual(
-        Object.keys(PostType.getFields()),
+        Object.keys(PostType.getFields())
     );
     expect(typeMap['User'].name).toEqual(UserType.name);
     expect(Object.keys(typeMap['User'].getFields())).toEqual(
-        Object.keys(UserType.getFields()),
+        Object.keys(UserType.getFields())
     );
 });
 

--- a/src/introspection/getTypeFromValues.js
+++ b/src/introspection/getTypeFromValues.js
@@ -42,25 +42,25 @@ export default (name, values = [], isRequired = false) => {
             if (valuesAreBoolean(leafValues)) {
                 return requiredTypeOrNormal(
                     new GraphQLList(GraphQLBoolean),
-                    isRequired,
+                    isRequired
                 );
             }
             if (valuesAreString(leafValues)) {
                 return requiredTypeOrNormal(
                     new GraphQLList(GraphQLString),
-                    isRequired,
+                    isRequired
                 );
             }
             if (valuesAreInteger(leafValues)) {
                 return requiredTypeOrNormal(
                     new GraphQLList(GraphQLInt),
-                    isRequired,
+                    isRequired
                 );
             }
             if (valuesAreNumeric(leafValues)) {
                 return requiredTypeOrNormal(
                     new GraphQLList(GraphQLFloat),
-                    isRequired,
+                    isRequired
                 );
             }
             if (valuesAreObject(leafValues)) {
@@ -68,7 +68,7 @@ export default (name, values = [], isRequired = false) => {
             }
             return requiredTypeOrNormal(
                 new GraphQLList(GraphQLString),
-                isRequired,
+                isRequired
             ); // FIXME introspect further
         }
         if (valuesAreBoolean(values)) {

--- a/src/introspection/getTypeFromValues.spec.js
+++ b/src/introspection/getTypeFromValues.spec.js
@@ -18,22 +18,22 @@ test('returns GraphQLID for fields named id or xxx_id', () => {
 
 test('returns GraphQLList for arrays', () => {
     expect(getTypeFromValues('foo', [[true, false], [true]])).toEqual(
-        new GraphQLList(GraphQLBoolean),
+        new GraphQLList(GraphQLBoolean)
     );
     expect(getTypeFromValues('foo', [['a', 'b'], ['c', 'd']])).toEqual(
-        new GraphQLList(GraphQLString),
+        new GraphQLList(GraphQLString)
     );
     expect(getTypeFromValues('foo', [[123, 456], [789, 123]])).toEqual(
-        new GraphQLList(GraphQLInt),
+        new GraphQLList(GraphQLInt)
     );
     expect(getTypeFromValues('foo', [[1.23, 456], [-5, 123]])).toEqual(
-        new GraphQLList(GraphQLFloat),
+        new GraphQLList(GraphQLFloat)
     );
 });
 
 test('returns GraphQLBoolean for booleans', () =>
     expect(getTypeFromValues('foo', [true, true, false])).toEqual(
-        GraphQLBoolean,
+        GraphQLBoolean
     ));
 
 test('returns GraphQLString for strings', () => {
@@ -49,22 +49,22 @@ test('returns GraphQLFloat for floats', () =>
 
 test('returns DateType for Dates', () =>
     expect(
-        getTypeFromValues('foo', [new Date('2017-03-15'), new Date()]),
+        getTypeFromValues('foo', [new Date('2017-03-15'), new Date()])
     ).toEqual(DateType));
 
 test('returns GraphQLJSON for objects', () =>
     expect(
-        getTypeFromValues('foo', [{ foo: 1 }, { bar: 2 }, { id: 'a' }]),
+        getTypeFromValues('foo', [{ foo: 1 }, { bar: 2 }, { id: 'a' }])
     ).toEqual(GraphQLJSON));
 
 test('returns GraphQLJSON for arrays of objects', () =>
     expect(
-        getTypeFromValues('foo', [[{ foo: 1 }, { bar: 2 }], [{ id: 'a' }]]),
+        getTypeFromValues('foo', [[{ foo: 1 }, { bar: 2 }], [{ id: 'a' }]])
     ).toEqual(GraphQLJSON));
 
 test('returns GraphQLString for mixed values', () =>
     expect(getTypeFromValues('foo', [0, '&', new Date()])).toEqual(
-        GraphQLString,
+        GraphQLString
     ));
 
 test('returns GraphQLString for no values', () =>
@@ -72,5 +72,5 @@ test('returns GraphQLString for no values', () =>
 
 test('returns GraphQLNonNull when all values are filled', () =>
     expect(getTypeFromValues('foo', [], true)).toEqual(
-        new GraphQLNonNull(GraphQLString),
+        new GraphQLNonNull(GraphQLString)
     ));

--- a/src/introspection/getValuesFromEntities.spec.js
+++ b/src/introspection/getValuesFromEntities.spec.js
@@ -7,7 +7,7 @@ test('does not take empty values into account', () => {
 });
 test('returns an array of values for every field', () => {
     expect(
-        getValuesFromEntities([{ id: 1, foo: 'bar' }, { id: 2, foo: 'baz' }]),
+        getValuesFromEntities([{ id: 1, foo: 'bar' }, { id: 2, foo: 'baz' }])
     ).toEqual({
         id: [1, 2],
         foo: ['bar', 'baz'],
@@ -24,7 +24,7 @@ test('can handle sparse fieldsets', () => {
             { id: 1, foo: 'foo1' },
             { id: 2, foo: 'foo2', bar: 'bar1' },
             { id: 3, bar: 'bar2' },
-        ]),
+        ])
     ).toEqual({
         id: [1, 2, 3],
         foo: ['foo1', 'foo2'],

--- a/src/jsonGraphqlExpress.js
+++ b/src/jsonGraphqlExpress.js
@@ -3,14 +3,14 @@ import schemaBuilder from './schemaBuilder';
 
 /**
  * An express middleware for a GraphQL endpoint serving data from the supplied json.
- * 
- * @param {any} data 
+ *
+ * @param {any} data
  * @returns An array of middlewares
- * 
+ *
  * @example
  * import express from 'express';
  * import { jsonGraphqlExpress } from 'json-graphql-server';
- * 
+ *
  * const data = {
  *    "posts": [
  *        {
@@ -37,12 +37,12 @@ import schemaBuilder from './schemaBuilder';
  *        }
  *    ],
  * };
- * 
+ *
  * const PORT = 3000;
  * var app = express();
- * 
+ *
  * app.use('/graphql', jsonGraphqlExpress(data));
- * 
+ *
  * app.listen(PORT);
  */
 export default data =>

--- a/src/resolver/Entity/index.js
+++ b/src/resolver/Entity/index.js
@@ -58,10 +58,10 @@ export default (entityName, data) => {
             Object.assign({}, resolvers, {
                 [getRelatedType(fieldName)]: entity =>
                     data[getRelatedKey(fieldName)].find(
-                        relatedRecord => relatedRecord.id == entity[fieldName],
+                        relatedRecord => relatedRecord.id == entity[fieldName]
                     ),
             }),
-        {},
+        {}
     );
     const relatedField = getReverseRelatedField(entityName); // 'posts' => 'post_id'
     const hasReverseRelationship = entityName =>
@@ -72,10 +72,10 @@ export default (entityName, data) => {
             Object.assign({}, resolvers, {
                 [getRelationshipFromKey(entityName)]: entity =>
                     data[entityName].filter(
-                        record => record[relatedField] == entity.id,
+                        record => record[relatedField] == entity.id
                     ),
             }),
-        {},
+        {}
     );
 
     return Object.assign({}, manyToOneResolvers, oneToManyResolvers);

--- a/src/resolver/Mutation/update.js
+++ b/src/resolver/Mutation/update.js
@@ -5,7 +5,7 @@ export default (entityData = []) => (_, params) => {
         entityData[indexOfEntity] = Object.assign(
             {},
             entityData[indexOfEntity],
-            params,
+            params
         );
         return entityData[indexOfEntity];
     }

--- a/src/resolver/Query/all.js
+++ b/src/resolver/Query/all.js
@@ -1,6 +1,6 @@
 export default (entityData = []) => (
     _,
-    { sortField, sortOrder = 'asc', page, perPage = 25, filter = {} },
+    { sortField, sortOrder = 'asc', page, perPage = 25, filter = {} }
 ) => {
     let items = [...entityData];
 
@@ -49,7 +49,7 @@ export default (entityData = []) => (
                 d =>
                     filter[key] instanceof Date
                         ? +d[key] == +filter[key]
-                        : d[key] == filter[key],
+                        : d[key] == filter[key]
             );
         });
 
@@ -61,8 +61,8 @@ export default (entityData = []) => (
                         d[key]
                             .toString()
                             .toLowerCase()
-                            .includes(filter.q.toLowerCase()),
-                ),
+                            .includes(filter.q.toLowerCase())
+                )
             );
         }
     }

--- a/src/resolver/Query/all.spec.js
+++ b/src/resolver/Query/all.spec.js
@@ -70,14 +70,14 @@ describe('sort', () => {
     });
     test('sorts data using sortOrder for the sort direction', () => {
         expect(
-            all(data)(null, { sortField: 'views', sortOrder: 'asc' }),
+            all(data)(null, { sortField: 'views', sortOrder: 'asc' })
         ).toEqual([
             { id: 2, title: 'Ut enim ad minim', user_id: 456, views: 65 },
             { id: 3, title: 'Sic Dolor amet', user_id: 123, views: 76 },
             { id: 1, title: 'Lorem Ipsum', user_id: 123, views: 254 },
         ]);
         expect(
-            all(data)(null, { sortField: 'views', sortOrder: 'desc' }),
+            all(data)(null, { sortField: 'views', sortOrder: 'desc' })
         ).toEqual([
             { id: 1, title: 'Lorem Ipsum', user_id: 123, views: 254 },
             { id: 3, title: 'Sic Dolor amet', user_id: 123, views: 76 },
@@ -100,7 +100,7 @@ describe('filter', () => {
             { id: 2, title: 'Ut enim ad minim', user_id: 456, views: 65 },
         ]);
         expect(
-            all(data)(null, { filter: { title: 'Sic Dolor amet' } }),
+            all(data)(null, { filter: { title: 'Sic Dolor amet' } })
         ).toEqual([
             { id: 3, title: 'Sic Dolor amet', user_id: 123, views: 76 },
         ]);

--- a/src/resolver/Query/meta.js
+++ b/src/resolver/Query/meta.js
@@ -37,8 +37,8 @@ export default entityData => (_, { page, perPage = 25, filter = '{}' }) => {
         if (filters.q) {
             items = items.filter(d =>
                 Object.keys(d).some(key =>
-                    d[key].toString().includes(filters.q),
-                ),
+                    d[key].toString().includes(filters.q)
+                )
             );
         }
     }

--- a/src/resolver/index.js
+++ b/src/resolver/index.js
@@ -33,18 +33,18 @@ export default data => {
                     Object.assign(
                         {},
                         resolvers,
-                        getQueryResolvers(getTypeFromKey(key), data[key]),
+                        getQueryResolvers(getTypeFromKey(key), data[key])
                     ),
-                {},
+                {}
             ),
             Mutation: Object.keys(data).reduce(
                 (resolvers, key) =>
                     Object.assign(
                         {},
                         resolvers,
-                        getMutationResolvers(getTypeFromKey(key), data[key]),
+                        getMutationResolvers(getTypeFromKey(key), data[key])
                     ),
-                {},
+                {}
             ),
         },
         Object.keys(data).reduce(
@@ -52,9 +52,9 @@ export default data => {
                 Object.assign({}, resolvers, {
                     [getTypeFromKey(key)]: entityResolver(key, data),
                 }),
-            {},
+            {}
         ),
         hasType('Date', data) ? { Date: DateType } : {}, // required because makeExecutableSchema strips resolvers from typeDefs
-        hasType('JSON', data) ? { JSON: GraphQLJSON } : {}, // required because makeExecutableSchema strips resolvers from typeDefs
+        hasType('JSON', data) ? { JSON: GraphQLJSON } : {} // required because makeExecutableSchema strips resolvers from typeDefs
     );
 };

--- a/src/schemaBuilder.spec.js
+++ b/src/schemaBuilder.spec.js
@@ -8,7 +8,7 @@ test('plugs resolvers with schema', () => {
     return graphql(schema, 'query { Post(id: 0) { id title } }').then(result =>
         expect(result).toEqual({
             data: { Post: { id: '0', title: 'hello' } },
-        }),
+        })
     );
 });
 
@@ -49,7 +49,7 @@ test('all* route returns all entities by default', () =>
             data: {
                 allPosts: [{ id: '1' }, { id: '2' }, { id: '3' }],
             },
-        }),
+        })
     ));
 test('all* route supports pagination', () =>
     graphql(schema, '{ allPosts(page: 0, perPage: 2) { id } }').then(result =>
@@ -57,18 +57,18 @@ test('all* route supports pagination', () =>
             data: {
                 allPosts: [{ id: '1' }, { id: '2' }],
             },
-        }),
+        })
     ));
 test('all* route supports sorting', () =>
     graphql(
         schema,
-        '{ allPosts(sortField: "views", sortOrder: "desc") { id } }',
+        '{ allPosts(sortField: "views", sortOrder: "desc") { id } }'
     ).then(result =>
         expect(result).toEqual({
             data: {
                 allPosts: [{ id: '1' }, { id: '3' }, { id: '2' }],
             },
-        }),
+        })
     ));
 test('all* route supports filtering', () =>
     graphql(schema, '{ allPosts(filter: { q: "lorem"}) { id } }').then(result =>
@@ -76,7 +76,7 @@ test('all* route supports filtering', () =>
             data: {
                 allPosts: [{ id: '1' }],
             },
-        }),
+        })
     ));
 test('entity route returns a single entity', () =>
     graphql(schema, '{ Post(id: 2) { id } }').then(result =>
@@ -84,7 +84,7 @@ test('entity route returns a single entity', () =>
             data: {
                 Post: { id: '2' },
             },
-        }),
+        })
     ));
 test('entity route gets all the entity fields', () =>
     graphql(schema, '{ Post(id: 1) { id title views user_id } }').then(result =>
@@ -97,13 +97,13 @@ test('entity route gets all the entity fields', () =>
                     views: 254,
                 },
             },
-        }),
+        })
     ));
 test('entity route get many to one relationships fields', () =>
     graphql(schema, '{ Post(id: 1) { User { name } } }').then(result =>
         expect(result).toEqual({
             data: { Post: { User: { name: 'John Doe' } } },
-        }),
+        })
     ));
 test('entity route get one to many relationships fields', () =>
     graphql(schema, '{ Post(id: 1) { Comments { body } } }').then(result =>
@@ -116,7 +116,7 @@ test('entity route get one to many relationships fields', () =>
                     ],
                 },
             },
-        }),
+        })
     ));
 test('returns an error when asked for a non existent field', () =>
     graphql(schema, '{ Post(id: 1) { foo } }').then(result =>
@@ -124,5 +124,5 @@ test('returns an error when asked for a non existent field', () =>
             errors: [
                 new GraphQLError('Cannot query field "foo" on type "Post".'),
             ],
-        }),
+        })
     ));


### PR DESCRIPTION
Change Trailing Comma Policy to match ES5 rules. Because in node < v8, trailing commas on functions args will not work.