### PR TITLE
Fix for calling update multiple times

### DIFF
--- a/src/jsonGraphqlExpress.spec.js
+++ b/src/jsonGraphqlExpress.spec.js
@@ -96,4 +96,18 @@ describe('integration tests', () => {
                 },
             },
         }));
+    it('allows multiple mutations', () =>
+        gqlAgent(
+            'mutation{ updatePost(id:"2", title:"Foo bar", views: 200, user_id:"123") { id } }'
+        ).then(() =>
+            gqlAgent(
+                'mutation{ updatePost(id:"2", title:"Foo bar", views: 200, user_id:"123") { id } }'
+            ).expect({
+                data: {
+                    updatePost: {
+                        id: 2,
+                    },
+                },
+            })
+        ));
 });

--- a/src/resolver/Mutation/update.js
+++ b/src/resolver/Mutation/update.js
@@ -1,6 +1,8 @@
 export default (entityData = []) => (_, params) => {
     const parsedId = parseInt(params.id, 10); // FIXME fails for non-integer ids
-    const indexOfEntity = entityData.findIndex(e => e.id === parsedId);
+    const indexOfEntity = entityData.findIndex(
+        e => parseInt(e.id, 10) === parsedId
+    );
     if (indexOfEntity !== -1) {
         entityData[indexOfEntity] = Object.assign(
             {},


### PR DESCRIPTION
Fixes #31 

There's inconsistencies in the type of the id that's being stored in memory. It looks like after parsing the data file it stores ids as integers in memory, but when we perform an update that update occurs as a string. Avoiding major changes, this always compares ids as integers so we don't need to worry about the inconsistencies.