### PR TITLE
Correct the link to GraphiQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Go to http://localhost:3000/?query=%7B%20Post%28id%3A%201%29%20%7B%20id%20title%
 
 The json-graphql-server accepts queries in GET and POST. Under the hood, it uses [the `express-graphql` module](https://github.com/graphql/express-graphql). Please refer to their documentations for details about passing variables, etc.
 
-Note that the server is [GraphiQL](https://github.com/skevy/graphiql-app/releases) enabled, so you can query your server using a full-featured graphical user interface, providing autosuggest, history, etc.
+Note that the server is [GraphiQL](https://github.com/graphql/graphiql) enabled, so you can query your server using a full-featured graphical user interface, providing autosuggest, history, etc.
 
 ![GraphiQL client using json-graphql-server](http://static.marmelab.com/graphiql-json.png)
 


### PR DESCRIPTION
On README the link to GraphiQL is pointing to wrong URL. Here's the real one.