### PR TITLE
Fix Audit Issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "env": {
     "test": {
       "presets": [
-        "es2015",
+        "env",
         "stage-0"
       ],
       "plugins": [
@@ -13,7 +13,7 @@
     "development": {
       "presets": [
         [
-          "es2015",
+          "env",
           {
             "modules": false
           }
@@ -28,7 +28,7 @@
     "production": {
       "presets": [
         [
-          "es2015",
+          "env",
           {
             "modules": false
           }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,19 @@
 {
     "name": "json-graphql-server",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "main": "lib/json-graphql-server.node.min.js",
     "browser": "lib/json-graphql-server.client.min.js",
     "repository": "git@github.com:marmelab/json-graphql-server.git",
-    "authors": ["François Zaninotto", "Gildas Garcia"],
-    "files": ["*.md", "lib", "src", "bin"],
+    "authors": [
+        "François Zaninotto",
+        "Gildas Garcia"
+    ],
+    "files": [
+        "*.md",
+        "lib",
+        "src",
+        "bin"
+    ],
     "license": "MIT",
     "scripts": {
         "format": "make format",
@@ -16,45 +24,48 @@
         "prepublish": "make build"
     },
     "lint-staged": {
-        "src/**/*.js": ["eslint --fix", "git add"]
+        "src/**/*.js": [
+            "eslint --fix",
+            "git add"
+        ]
     },
     "devDependencies": {
-        "@types/jest": "~19.2.4",
-        "babel-cli": "~6.24.1",
-        "babel-core": "~6.25.0",
-        "babel-eslint": "~7.2.3",
-        "babel-jest": "~20.0.3",
-        "babel-loader": "7.1.2",
-        "babel-plugin-add-module-exports": "^0.2.1",
+        "@types/jest": "~23.3.9",
+        "babel-cli": "~6.26.0",
+        "babel-core": "~6.26.3",
+        "babel-eslint": "~10.0.1",
+        "babel-jest": "~23.6.0",
+        "babel-loader": "8.0.4",
+        "babel-plugin-add-module-exports": "^1.0.0",
         "babel-plugin-external-helpers": "~6.22.0",
         "babel-plugin-transform-runtime": "~6.23.0",
-        "babel-preset-es2015": "~6.24.1",
         "babel-preset-stage-0": "~6.24.1",
-        "eslint": "~4.2.0",
-        "eslint-config-prettier": "~2.3.0",
-        "eslint-plugin-import": "~2.7.0",
-        "eslint-plugin-jest": "~20.0.3",
-        "eslint-plugin-prettier": "~2.1.2",
-        "husky": "~0.13.3",
-        "jest": "~20.0.4",
-        "lint-staged": "~3.4.1",
-        "prettier": "~1.5.2",
-        "supertest": "~3.0.0",
-        "webpack": "~3.10.0"
+        "eslint": "~5.9.0",
+        "eslint-config-prettier": "~3.3.0",
+        "eslint-plugin-import": "~2.14.0",
+        "eslint-plugin-jest": "~22.0.1",
+        "eslint-plugin-prettier": "~3.0.0",
+        "husky": "~1.2.0",
+        "jest": "~23.6.0",
+        "lint-staged": "~8.1.0",
+        "prettier": "~1.15.2",
+        "supertest": "~3.3.0",
+        "webpack": "~4.26.1"
     },
     "dependencies": {
-        "apollo-client": "~1.2.0",
+        "apollo-client": "~2.4.7",
         "apollo-test-utils": "~0.3.2",
+        "@babel/preset-env": "^7.1.6",
         "cors": "^2.8.4",
-        "express": "~4.15.3",
-        "express-graphql": "~0.6.7",
-        "graphql": "~0.10.5",
-        "graphql-tag": "~2.0.0",
-        "graphql-tools": "~1.1.0",
-        "graphql-type-json": "~0.1.4",
+        "express": "~4.16.4",
+        "express-graphql": "~0.7.1",
+        "graphql": "~14.0.2",
+        "graphql-tag": "~2.10.0",
+        "graphql-tools": "~4.0.3",
+        "graphql-type-json": "~0.2.1",
         "inflection": "~1.12.0",
         "lodash.merge": "~4.6.0",
-        "reify": "~0.12.0",
+        "reify": "~0.18.1",
         "xhr-mock": "^2.0.3"
     },
     "bin": {


### PR DESCRIPTION
                       === npm audit security report ===


                                 Manual Review
             Some vulnerabilities require your attention to resolve

          Visit https://go.npm.me/audit-guide for additional guidance


  Moderate        Regular Expression Denial of Service

  Package         mime

  Patched in      >= 1.4.1 < 2.0.0 || >= 2.0.3

  Dependency of   json-graphql-server [dev]

  Path            json-graphql-server > express > send > mime

  More info       https://nodesecurity.io/advisories/535


  Moderate        Regular Expression Denial of Service

  Package         mime

  Patched in      >= 1.4.1 < 2.0.0 || >= 2.0.3

  Dependency of   json-graphql-server [dev]

  Path            json-graphql-server > express > serve-static > send > mime

  More info       https://nodesecurity.io/advisories/535

found 2 moderate severity vulnerabilities in 39798 scanned packages
  2 vulnerabilities require manual review. See the full report for details.