### PR TITLE
Adds support for getting random items from the JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Based on your data, json-graphql-server will generate a schema with one type per
 type Query {
   Post(id: ID!): Post
   allPosts(page: Int, perPage: Int, sortField: String, sortOrder: String, filter: PostFilter): [Post]
+  randomPosts(count: Int, filter: PostFilter): [Post]
   _allPostsMeta(page: Int, perPage: Int, sortField: String, sortOrder: String, filter: PostFilter): ListMetadata
 }
 type Mutation {

--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -111,6 +111,13 @@ export default data => {
                     filter: { type: filterTypesByName[type.name] },
                 },
             };
+            fields[`random${camelize(pluralize(type.name))}`] = {
+                type: new GraphQLList(typesByName[type.name]),
+                args: {
+                    count: { type: GraphQLInt },
+                    filter: { type: filterTypesByName[type.name] },
+                },
+            };
             fields[`_all${camelize(pluralize(type.name))}Meta`] = {
                 type: listMetadataType,
                 args: {

--- a/src/introspection/getSchemaFromData.spec.js
+++ b/src/introspection/getSchemaFromData.spec.js
@@ -125,7 +125,7 @@ test('creates one field per reverse relationship', () => {
     expect(Object.keys(typeMap['User'].getFields())).toContain('Posts');
 });
 
-test('creates three query fields per data type', () => {
+test('creates four query fields per data type', () => {
     const queries = getSchemaFromData(data).getQueryType().getFields();
     expect(queries['Post'].type.name).toEqual(PostType.name);
     expect(queries['Post'].args).toEqual([
@@ -149,6 +149,14 @@ test('creates three query fields per data type', () => {
     expect(queries['allPosts'].args[4].type.toString()).toEqual('PostFilter');
     expect(queries['_allPostsMeta'].type.toString()).toEqual('ListMetadata');
 
+    expect(queries['randomPosts'].type.toString()).toEqual('[Post]');
+    expect(queries['randomPosts'].args[0].name).toEqual('count');
+    expect(queries['randomPosts'].args[0].type).toEqual(GraphQLInt);
+    expect(queries['randomPosts'].args[1].name).toEqual('filter');
+    expect(queries['randomPosts'].args[1].type.toString()).toEqual(
+        'PostFilter'
+    );
+
     expect(queries['User'].type.name).toEqual(UserType.name);
     expect(queries['User'].args).toEqual([
         {
@@ -170,6 +178,14 @@ test('creates three query fields per data type', () => {
     expect(queries['allUsers'].args[4].name).toEqual('filter');
     expect(queries['allUsers'].args[4].type.toString()).toEqual('UserFilter');
     expect(queries['_allPostsMeta'].type.toString()).toEqual('ListMetadata');
+
+    expect(queries['randomUsers'].type.toString()).toEqual('[User]');
+    expect(queries['randomUsers'].args[0].name).toEqual('count');
+    expect(queries['randomUsers'].args[0].type).toEqual(GraphQLInt);
+    expect(queries['randomUsers'].args[1].name).toEqual('filter');
+    expect(queries['randomUsers'].args[1].type.toString()).toEqual(
+        'UserFilter'
+    );
 });
 
 test('creates three mutation fields per data type', () => {

--- a/src/jsonGraphqlExpress.spec.js
+++ b/src/jsonGraphqlExpress.spec.js
@@ -84,6 +84,18 @@ describe('integration tests', () => {
                 },
             ],
         }));
+    it('handles getting random items', () =>
+        gqlAgent('{ randomPosts { id } }').expect(response => {
+            expect(response.body).toEqual({
+                data: {
+                    randomPosts: [
+                        { id: expect.anything() },
+                        { id: expect.anything() },
+                        { id: expect.anything() },
+                    ],
+                },
+            });
+        }));
     it('gets relationship fields', () =>
         gqlAgent('{ Post(id: 1) { User { name } Comments { body }} }').expect({
             data: {

--- a/src/resolver/Query/random.js
+++ b/src/resolver/Query/random.js
@@ -1,0 +1,18 @@
+import applyFilters from './applyFilters';
+
+const getRandomNumber = (min, max) =>
+    Math.floor(Math.random() * (max - min + 1)) + min;
+
+export default (entityData = []) => (_, { count = 3, filter = {} }) => {
+    let items = [...entityData];
+
+    items = applyFilters(items, filter);
+    // cut down to count items
+    let returnCount = Math.min(count, items.length);
+    let randomItems = [];
+    for (let i = 0; i < returnCount; i++) {
+        randomItems.push(items[getRandomNumber(0, returnCount - 1)]);
+    }
+
+    return randomItems;
+};

--- a/src/resolver/Query/random.js
+++ b/src/resolver/Query/random.js
@@ -5,13 +5,13 @@ const getRandomNumber = (min, max) =>
 
 export default (entityData = []) => (_, { count = 3, filter = {} }) => {
     let items = [...entityData];
-
     items = applyFilters(items, filter);
+
     // cut down to count items
     let returnCount = Math.min(count, items.length);
     let randomItems = [];
     for (let i = 0; i < returnCount; i++) {
-        randomItems.push(items[getRandomNumber(0, returnCount - 1)]);
+        randomItems.push(items[getRandomNumber(0, items.length - 1)]);
     }
 
     return randomItems;

--- a/src/resolver/index.js
+++ b/src/resolver/index.js
@@ -3,6 +3,7 @@ import GraphQLJSON from 'graphql-type-json';
 
 import all from './Query/all';
 import meta from './Query/meta';
+import random from './Query/random';
 import single from './Query/single';
 import create from './Mutation/create';
 import update from './Mutation/update';
@@ -14,6 +15,7 @@ import hasType from '../introspection/hasType';
 
 const getQueryResolvers = (entityName, data) => ({
     [`all${pluralize(entityName)}`]: all(data),
+    [`random${pluralize(entityName)}`]: random(data),
     [`_all${pluralize(entityName)}Meta`]: meta(data),
     [entityName]: single(data),
 });


### PR DESCRIPTION
Extends the default set of resolvers created for a model to also include a way to get an arbitrary amount of items.

I built this because I'm building a graphql [wrapper](https://site-oqfeqysxya.now.sh/graphql?query=%7B%0A%20%20allGenes(page%3A%205)%20%7B%0A%20%20%20%20geneName%0A%20%20%20%20geneFamily%0A%20%20%20%20description%0A%20%20%7D%0A%7D) for a [pretty big dataset](https://github.com/artsy/the-art-genome-project), and wanted to be able to pluck out just one somehow.