### PR TITLE
Adds support for making a readonly schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,24 @@ app.use('/graphql', jsonGraphqlExpress(data));
 app.listen(PORT);
 ```
 
+## Options
+
+`jsonGraphqlExpress` accepts a second argument with an options object.
+
+```js
+import express from 'express';
+import jsonGraphqlExpress from 'json-graphql-server';
+
+// Skips creating mutations for the data
+const options = {
+  readonly: true
+}
+
+app.use('/graphql', jsonGraphqlExpress(data, options));
+```
+
+Currently only `readonly` is available as an option.
+
 ## Usage in browser with XMLHttpRequest
 
 Useful when using XMLHttpRequest directly or libaries such as [axios](https://www.npmjs.com/package/axios).

--- a/bin/json-graphql-server.js
+++ b/bin/json-graphql-server.js
@@ -9,20 +9,25 @@ var dataFilePath = process.argv.length > 2 ? process.argv[2] : './data.json';
 var data = require(path.join(process.cwd(), dataFilePath));
 var PORT = process.env.NODE_PORT || 3000;
 var app = express();
+var options = {};
 
 process.argv.forEach((arg, index) => {
-  // allow a custom port via CLI
-  if (arg === '--p' && process.argv.length > index + 1) {
-    PORT = process.argv[index + 1];
-  }
+    // allow a custom port via CLI
+    if (arg === '--p' && process.argv.length > index + 1) {
+        PORT = process.argv[index + 1];
+    }
+    // Allow declaring the API as readonly
+    if (arg === '--readonly') {
+        options.readonly = true;
+    }
 });
 
 app.use(cors());
-app.use('/', JsonGraphqlServer(data));
+app.use('/', JsonGraphqlServer(data, options));
 app.listen(PORT);
 var msg = `GraphQL server running with your data at http://localhost:${PORT}/`;
 console.log(msg); // eslint-disable-line no-console
 
 process.on('unhandledRejection', (reason, p) => {
-  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
+    console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
 });

--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -76,7 +76,7 @@ import { getRelatedType } from '../nameConverter';
  * //     removeUser(id: ID!): Boolean
  * // }
  */
-export default data => {
+export default (data, options) => {
     const types = getTypesFromData(data);
     const typesByName = types.reduce((types, type) => {
         types[type.name] = type;
@@ -125,36 +125,39 @@ export default data => {
 
     const mutationType = new GraphQLObjectType({
         name: 'Mutation',
-        fields: types.reduce((fields, type) => {
-            const typeFields = typesByName[type.name].getFields();
-            const nullableTypeFields = Object.keys(
-                typeFields
-            ).reduce((f, fieldName) => {
-                f[fieldName] = Object.assign({}, typeFields[fieldName], {
-                    type:
-                        fieldName !== 'id' &&
-                        typeFields[fieldName].type instanceof GraphQLNonNull
-                            ? typeFields[fieldName].type.ofType
-                            : typeFields[fieldName].type,
-                });
-                return f;
-            }, {});
-            fields[`create${type.name}`] = {
-                type: typesByName[type.name],
-                args: typeFields,
-            };
-            fields[`update${type.name}`] = {
-                type: typesByName[type.name],
-                args: nullableTypeFields,
-            };
-            fields[`remove${type.name}`] = {
-                type: GraphQLBoolean,
-                args: {
-                    id: { type: new GraphQLNonNull(GraphQLID) },
-                },
-            };
-            return fields;
-        }, {}),
+        fields: options.readonly
+            ? {}
+            : types.reduce((fields, type) => {
+                  const typeFields = typesByName[type.name].getFields();
+                  const nullableTypeFields = Object.keys(
+                      typeFields
+                  ).reduce((f, fieldName) => {
+                      f[fieldName] = Object.assign({}, typeFields[fieldName], {
+                          type:
+                              fieldName !== 'id' &&
+                              typeFields[fieldName].type instanceof
+                                  GraphQLNonNull
+                                  ? typeFields[fieldName].type.ofType
+                                  : typeFields[fieldName].type,
+                      });
+                      return f;
+                  }, {});
+                  fields[`create${type.name}`] = {
+                      type: typesByName[type.name],
+                      args: typeFields,
+                  };
+                  fields[`update${type.name}`] = {
+                      type: typesByName[type.name],
+                      args: nullableTypeFields,
+                  };
+                  fields[`remove${type.name}`] = {
+                      type: GraphQLBoolean,
+                      args: {
+                          id: { type: new GraphQLNonNull(GraphQLID) },
+                      },
+                  };
+                  return fields;
+              }, {}),
     });
 
     const schema = new GraphQLSchema({

--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -162,7 +162,7 @@ export default (data, options) => {
 
     const schema = new GraphQLSchema({
         query: queryType,
-        mutation: mutationType,
+        mutation: options.readonly ? undefined : mutationType,
     });
 
     /**

--- a/src/introspection/getSchemaFromData.spec.js
+++ b/src/introspection/getSchemaFromData.spec.js
@@ -104,7 +104,7 @@ const QueryType = new GraphQLObjectType({
 */
 
 test('creates one type per data type', () => {
-    const typeMap = getSchemaFromData(data).getTypeMap();
+    const typeMap = getSchemaFromData(data, {}).getTypeMap();
     expect(typeMap['Post'].name).toEqual(PostType.name);
     expect(Object.keys(typeMap['Post'].getFields())).toEqual(
         Object.keys(PostType.getFields())
@@ -116,17 +116,17 @@ test('creates one type per data type', () => {
 });
 
 test('creates one field per relationship', () => {
-    const typeMap = getSchemaFromData(data).getTypeMap();
+    const typeMap = getSchemaFromData(data, {}).getTypeMap();
     expect(Object.keys(typeMap['Post'].getFields())).toContain('User');
 });
 
 test('creates one field per reverse relationship', () => {
-    const typeMap = getSchemaFromData(data).getTypeMap();
+    const typeMap = getSchemaFromData(data, {}).getTypeMap();
     expect(Object.keys(typeMap['User'].getFields())).toContain('Posts');
 });
 
 test('creates three query fields per data type', () => {
-    const queries = getSchemaFromData(data).getQueryType().getFields();
+    const queries = getSchemaFromData(data, {}).getQueryType().getFields();
     expect(queries['Post'].type.name).toEqual(PostType.name);
     expect(queries['Post'].args).toEqual([
         {
@@ -173,7 +173,7 @@ test('creates three query fields per data type', () => {
 });
 
 test('creates three mutation fields per data type', () => {
-    const mutations = getSchemaFromData(data).getMutationType().getFields();
+    const mutations = getSchemaFromData(data, {}).getMutationType().getFields();
     expect(mutations['createPost'].type.name).toEqual(PostType.name);
     expect(mutations['createPost'].args).toEqual([
         {
@@ -283,12 +283,20 @@ test('pluralizes and capitalizes correctly', () => {
         feet: [{ id: 1, size: 42 }, { id: 2, size: 39 }],
         categories: [{ id: 1, name: 'foo' }],
     };
-    const queries = getSchemaFromData(data).getQueryType().getFields();
+    const queries = getSchemaFromData(data, {}).getQueryType().getFields();
     expect(queries).toHaveProperty('Foot');
     expect(queries).toHaveProperty('Category');
     expect(queries).toHaveProperty('allFeet');
     expect(queries).toHaveProperty('allCategories');
-    const types = getSchemaFromData(data).getTypeMap();
+    const types = getSchemaFromData(data, {}).getTypeMap();
     expect(types).toHaveProperty('Foot');
     expect(types).toHaveProperty('Category');
+});
+
+describe('With options', () => {
+    test('readonly skips  mutation fields per data type', () => {
+        const options = { readonly: true };
+        const mutation = getSchemaFromData(data, options).getMutationType();
+        expect(mutation).toBeNull();
+    });
 });

--- a/src/jsonGraphqlExpress.js
+++ b/src/jsonGraphqlExpress.js
@@ -5,6 +5,8 @@ import schemaBuilder from './schemaBuilder';
  * An express middleware for a GraphQL endpoint serving data from the supplied json.
  *
  * @param {any} data
+ * @param {Object} options
+ * @param {Boolean} options.readonly Whether mutations should be created, defaults to false
  * @returns An array of middlewares
  *
  * @example
@@ -45,8 +47,8 @@ import schemaBuilder from './schemaBuilder';
  *
  * app.listen(PORT);
  */
-export default data =>
+export default (data, options) =>
     graphqlHTTP({
-        schema: schemaBuilder(data),
+        schema: schemaBuilder(data, options),
         graphiql: true,
     });

--- a/src/jsonGraphqlExpress.js
+++ b/src/jsonGraphqlExpress.js
@@ -49,6 +49,6 @@ import schemaBuilder from './schemaBuilder';
  */
 export default (data, options) =>
     graphqlHTTP({
-        schema: schemaBuilder(data, options),
+        schema: schemaBuilder(data, options || {}),
         graphiql: true,
     });

--- a/src/resolver/index.js
+++ b/src/resolver/index.js
@@ -24,7 +24,7 @@ const getMutationResolvers = (entityName, data) => ({
     [`remove${entityName}`]: remove(data),
 });
 
-export default data => {
+export default (data, options) => {
     return Object.assign(
         {},
         {
@@ -37,16 +37,23 @@ export default data => {
                     ),
                 {}
             ),
-            Mutation: Object.keys(data).reduce(
-                (resolvers, key) =>
-                    Object.assign(
-                        {},
-                        resolvers,
-                        getMutationResolvers(getTypeFromKey(key), data[key])
-                    ),
-                {}
-            ),
         },
+        options.readonly
+            ? {}
+            : {
+                  Mutation: Object.keys(data).reduce(
+                      (resolvers, key) =>
+                          Object.assign(
+                              {},
+                              resolvers,
+                              getMutationResolvers(
+                                  getTypeFromKey(key),
+                                  data[key]
+                              )
+                          ),
+                      {}
+                  ),
+              },
         Object.keys(data).reduce(
             (resolvers, key) =>
                 Object.assign({}, resolvers, {

--- a/src/resolver/index.spec.js
+++ b/src/resolver/index.spec.js
@@ -1,0 +1,9 @@
+import resolver from '.';
+
+describe('With options', () => {
+    test('readonly skips creating the Mutation type', () => {
+        const options = { readonly: true };
+        const schemas = resolver({ posts: [] }, options);
+        expect(schemas.Mutation).toBeUndefined();
+    });
+});

--- a/src/schemaBuilder.js
+++ b/src/schemaBuilder.js
@@ -6,6 +6,6 @@ import resolver from './resolver';
 export default (data, options) =>
     makeExecutableSchema({
         typeDefs: printSchema(getSchemaFromData(data, options)),
-        resolvers: resolver(data),
+        resolvers: resolver(data, options),
         logger: { log: e => console.log(e) }, // eslint-disable-line no-console
     });

--- a/src/schemaBuilder.js
+++ b/src/schemaBuilder.js
@@ -3,9 +3,9 @@ import { printSchema } from 'graphql';
 import getSchemaFromData from './introspection/getSchemaFromData';
 import resolver from './resolver';
 
-export default data =>
+export default (data, options) =>
     makeExecutableSchema({
-        typeDefs: printSchema(getSchemaFromData(data)),
+        typeDefs: printSchema(getSchemaFromData(data, options)),
         resolvers: resolver(data),
         logger: { log: e => console.log(e) }, // eslint-disable-line no-console
     });

--- a/src/schemaBuilder.spec.js
+++ b/src/schemaBuilder.spec.js
@@ -2,9 +2,12 @@ import { graphql, GraphQLError } from 'graphql';
 import schemaBuilder from './schemaBuilder';
 
 test('plugs resolvers with schema', () => {
-    const schema = schemaBuilder({
-        posts: [{ id: 0, title: 'hello', foo: 'bar' }],
-    });
+    const schema = schemaBuilder(
+        {
+            posts: [{ id: 0, title: 'hello', foo: 'bar' }],
+        },
+        {}
+    );
     return graphql(schema, 'query { Post(id: 0) { id title } }').then(result =>
         expect(result).toEqual({
             data: { Post: { id: '0', title: 'hello' } },
@@ -41,7 +44,7 @@ const data = {
     ],
 };
 
-const schema = schemaBuilder(data);
+const schema = schemaBuilder(data, {});
 
 test('all* route returns all entities by default', () =>
     graphql(schema, '{ allPosts { id } }').then(result =>


### PR DESCRIPTION
The other part I needed with #62  was the ability to trust that the data isn't being mutated - this adds an options object to the exported API which includes a `readonly` option which ensures that there's no `Mutation` object in the schema.

<img width="1040" alt="screen shot 2019-02-15 at 4 35 39 pm" src="https://user-images.githubusercontent.com/49038/52885817-7610ef00-3140-11e9-9084-4714beeafa76.png">