### PR TITLE
Don't remove any entities when you try to remove a nonexistent entity

### DIFF
--- a/src/resolver/Mutation/remove.js
+++ b/src/resolver/Mutation/remove.js
@@ -1,8 +1,10 @@
 export default (entityData = []) => (_, { id }) => {
     const parsedId = parseInt(id, 10); // FIXME fails for non-integer ids
     const indexOfEntity = entityData.findIndex(e => e.id === parsedId);
-    const removedEntity = entityData[indexOfEntity];
+    let removedEntity = undefined;
 
-    entityData.splice(indexOfEntity, 1);
+    if (indexOfEntity !== -1) {
+        removedEntity = entityData.splice(indexOfEntity, 1)[0];
+    }
     return removedEntity;
 };

--- a/src/resolver/Mutation/remove.spec.js
+++ b/src/resolver/Mutation/remove.spec.js
@@ -7,11 +7,19 @@ test('returns undefined by default', () => {
 test('returns removed record when found', () => {
     const data = [{ id: 1, value: 'foo' }, { id: 2, value: 'bar' }];
     expect(remove(data)(null, { id: 1 })).toEqual({ id: 1, value: 'foo' });
+    expect(data).toEqual([{ id: 2, value: 'bar' }]);
 });
 
 test('returns undefined when not found', () => {
     const data = [{ id: 1, value: 'foo' }, { id: 2, value: 'bar' }];
     expect(remove(data)(null, { id: 3 })).toBeUndefined();
+});
+
+test('leaves data unmodified when not found', () => {
+    const data = [{ id: 1, value: 'foo' }, { id: 2, value: 'bar' }];
+    const originalData = [...data];
+    expect(remove(data)(null, { id: 3 })).toBeUndefined();
+    expect(data).toEqual(originalData);
 });
 
 test('removes record when found', () => {


### PR DESCRIPTION
This should fix the initial issue from #66, but not anything that came up in the comments, like the poor handling of string IDs.