### PR TITLE
Better handling of string IDs

### DIFF
--- a/src/resolver/Mutation/remove.js
+++ b/src/resolver/Mutation/remove.js
@@ -1,10 +1,14 @@
 export default (entityData = []) => (_, { id }) => {
-    const stringId = `${id}`;
-    const indexOfEntity = entityData.findIndex(e => `${e.id}` === stringId);
     let removedEntity = undefined;
+    if (id != null) {
+        const stringId = id.toString();
+        const indexOfEntity = entityData.findIndex(
+            e => e.id != null && e.id.toString() === stringId
+        );
 
-    if (indexOfEntity !== -1) {
-        removedEntity = entityData.splice(indexOfEntity, 1)[0];
+        if (indexOfEntity !== -1) {
+            removedEntity = entityData.splice(indexOfEntity, 1)[0];
+        }
     }
     return removedEntity;
 };

--- a/src/resolver/Mutation/remove.js
+++ b/src/resolver/Mutation/remove.js
@@ -1,6 +1,6 @@
 export default (entityData = []) => (_, { id }) => {
-    const parsedId = parseInt(id, 10); // FIXME fails for non-integer ids
-    const indexOfEntity = entityData.findIndex(e => e.id === parsedId);
+    const stringId = `${id}`;
+    const indexOfEntity = entityData.findIndex(e => `${e.id}` === stringId);
     let removedEntity = undefined;
 
     if (indexOfEntity !== -1) {

--- a/src/resolver/Mutation/remove.spec.js
+++ b/src/resolver/Mutation/remove.spec.js
@@ -39,3 +39,9 @@ test('removes with string input and data ids', () => {
     remove(data)(null, { id: 'abc' });
     expect(data).toEqual([{ id: 'def', value: 'bar' }]);
 });
+
+test("doesn't confuse undefined id with the id 'undefined'", () => {
+    const data = [{ value: 'foo' }, { id: 'def', value: 'bar' }];
+    expect(remove(data)(null, { id: 'undefined' })).toBeUndefined();
+    expect(data).toEqual([{ value: 'foo' }, { id: 'def', value: 'bar' }]);
+});

--- a/src/resolver/Mutation/remove.spec.js
+++ b/src/resolver/Mutation/remove.spec.js
@@ -27,3 +27,15 @@ test('removes record when found', () => {
     remove(data)(null, { id: 1 });
     expect(data).toEqual([{ id: 2, value: 'bar' }]);
 });
+
+test('removes with string data id', () => {
+    const data = [{ id: '1', value: 'foo' }, { id: '2', value: 'bar' }];
+    remove(data)(null, { id: 1 });
+    expect(data).toEqual([{ id: '2', value: 'bar' }]);
+});
+
+test('removes with string input and data ids', () => {
+    const data = [{ id: 'abc', value: 'foo' }, { id: 'def', value: 'bar' }];
+    remove(data)(null, { id: 'abc' });
+    expect(data).toEqual([{ id: 'def', value: 'bar' }]);
+});

--- a/src/resolver/Mutation/update.js
+++ b/src/resolver/Mutation/update.js
@@ -1,8 +1,6 @@
 export default (entityData = []) => (_, params) => {
-    const parsedId = parseInt(params.id, 10); // FIXME fails for non-integer ids
-    const indexOfEntity = entityData.findIndex(
-        e => parseInt(e.id, 10) === parsedId
-    );
+    const stringId = `${params.id}`;
+    const indexOfEntity = entityData.findIndex(e => `${e.id}` === stringId);
     if (indexOfEntity !== -1) {
         entityData[indexOfEntity] = Object.assign(
             {},

--- a/src/resolver/Mutation/update.js
+++ b/src/resolver/Mutation/update.js
@@ -1,12 +1,18 @@
 export default (entityData = []) => (_, params) => {
-    const stringId = `${params.id}`;
-    const indexOfEntity = entityData.findIndex(e => `${e.id}` === stringId);
-    if (indexOfEntity !== -1) {
-        entityData[indexOfEntity] = Object.assign(
-            {},
-            entityData[indexOfEntity],
-            params
+    let updatedEntity = undefined;
+    if (params.id != null) {
+        const stringId = params.id.toString();
+        const indexOfEntity = entityData.findIndex(
+            e => e.id != null && e.id.toString() === stringId
         );
-        return entityData[indexOfEntity];
+        if (indexOfEntity !== -1) {
+            entityData[indexOfEntity] = Object.assign(
+                {},
+                entityData[indexOfEntity],
+                params
+            );
+            updatedEntity = entityData[indexOfEntity];
+        }
     }
+    return updatedEntity;
 };

--- a/src/resolver/Mutation/update.spec.js
+++ b/src/resolver/Mutation/update.spec.js
@@ -35,3 +35,11 @@ test('removes property when setting the value to undefined', () => {
     update(data)(null, { id: 1, value: undefined });
     expect(data).toEqual([{ id: 1 }]);
 });
+
+test("doesn't confuse undefined id with the id 'undefined'", () => {
+    const data = [{ value: 'foo' }];
+    expect(
+        update(data)(null, { id: 'undefined', value: 'bar', bar: 'baz' })
+    ).toBeUndefined();
+    expect(data).toEqual([{ value: 'foo' }]);
+});

--- a/src/resolver/Mutation/update.spec.js
+++ b/src/resolver/Mutation/update.spec.js
@@ -24,6 +24,12 @@ test('updates record when found', () => {
     expect(data).toEqual([{ id: 1, value: 'bar', bar: 'baz' }]);
 });
 
+test('updates record with string id', () => {
+    const data = [{ id: 'abc', value: 'foo' }];
+    update(data)(null, { id: 'abc', value: 'bar', bar: 'baz' });
+    expect(data).toEqual([{ id: 'abc', value: 'bar', bar: 'baz' }]);
+});
+
 test('removes property when setting the value to undefined', () => {
     const data = [{ id: 1, value: 'foo' }];
     update(data)(null, { id: 1, value: undefined });


### PR DESCRIPTION
In the two places where parseInt was being used, instead normalize the
two IDs into strings so they can be compared.

This would close #66 by fixing the two bugs that were brought up in the comments.

1. Not being able to delete an entity whose ID is a string
2. Not being able to delete an entity after creating it (as opposed to putting it in the initial data).