### PR TITLE
Accept -p as custom port parameter

### DIFF
--- a/bin/json-graphql-server.js
+++ b/bin/json-graphql-server.js
@@ -12,7 +12,7 @@ var app = express();
 
 process.argv.forEach((arg, index) => {
   // allow a custom port via CLI
-  if (arg === '--p' && process.argv.length > index + 1) {
+  if ((arg === '-p' || arg === '--p') && process.argv.length > index + 1) {
     PORT = process.argv[index + 1];
   }
 });


### PR DESCRIPTION
## Description

Accept the port parameter `-p` as defined in the documentation. I didn't remove `--p` to avoid adding a breaking change for people already using it.

I can add the alternative in the documentation, but I think it's better to keep it as is and have it as the default flag.

## Related Issue

Fixes #85