### PR TITLE
Fix issue with Remove and Create function not incrementing the ID

### DIFF
--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -140,15 +140,7 @@ export default (data) => {
                 },
                 {}
             );
-            const createFields = Object.keys(typeFields).reduce(
-              (f, fieldName) => {
-                if (fieldName !== 'id') {
-                  f[fieldName] = Object.assign({}, typeFields[fieldName])
-                }
-                return f
-              },
-              {}
-            );
+            const { id, ...createFields } = typeFields;
             fields[`create${type.name}`] = {
                 type: typesByName[type.name],
                 args: createFields,

--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -140,16 +140,25 @@ export default (data) => {
                 },
                 {}
             );
+            const createFields = Object.keys(typeFields).reduce(
+              (f, fieldName) => {
+                if (fieldName !== 'id') {
+                  f[fieldName] = Object.assign({}, typeFields[fieldName])
+                }
+                return f
+              },
+              {}
+            );
             fields[`create${type.name}`] = {
                 type: typesByName[type.name],
-                args: typeFields,
+                args: createFields,
             };
             fields[`update${type.name}`] = {
                 type: typesByName[type.name],
                 args: nullableTypeFields,
             };
             fields[`remove${type.name}`] = {
-                type: GraphQLBoolean,
+                type: typesByName[type.name],
                 args: {
                     id: { type: new GraphQLNonNull(GraphQLID) },
                 },

--- a/src/introspection/getSchemaFromData.spec.js
+++ b/src/introspection/getSchemaFromData.spec.js
@@ -177,12 +177,6 @@ test('creates three mutation fields per data type', () => {
     expect(mutations['createPost'].type.name).toEqual(PostType.name);
     expect(mutations['createPost'].args).toEqual([
         {
-            name: 'id',
-            type: new GraphQLNonNull(GraphQLID),
-            defaultValue: undefined,
-            description: null,
-        },
-        {
             name: 'title',
             type: new GraphQLNonNull(GraphQLString),
             defaultValue: undefined,
@@ -228,7 +222,7 @@ test('creates three mutation fields per data type', () => {
             description: null,
         },
     ]);
-    expect(mutations['removePost'].type.name).toEqual(GraphQLBoolean.name);
+    expect(mutations['removePost'].type.name).toEqual(PostType.name);
     expect(mutations['removePost'].args).toEqual([
         {
             name: 'id',
@@ -239,12 +233,6 @@ test('creates three mutation fields per data type', () => {
     ]);
     expect(mutations['createUser'].type.name).toEqual(UserType.name);
     expect(mutations['createUser'].args).toEqual([
-        {
-            name: 'id',
-            type: new GraphQLNonNull(GraphQLID),
-            defaultValue: undefined,
-            description: null,
-        },
         {
             name: 'name',
             type: new GraphQLNonNull(GraphQLString),
@@ -267,7 +255,7 @@ test('creates three mutation fields per data type', () => {
             description: null,
         },
     ]);
-    expect(mutations['removeUser'].type.name).toEqual(GraphQLBoolean.name);
+    expect(mutations['removeUser'].type.name).toEqual(UserType.name);
     expect(mutations['removeUser'].args).toEqual([
         {
             defaultValue: undefined,

--- a/src/resolver/Mutation/create.js
+++ b/src/resolver/Mutation/create.js
@@ -1,8 +1,7 @@
 export default (entityData = []) => (_, entity) => {
     const newId =
-        entityData.length > 0 ? entityData[entityData.length - 1].id + 1 : 0;
-    const newEntity = Object.assign({ id: newId }, entity);
-
+        entityData.length > 0 ? entityData[entityData.length - 1].id + 1 : 1;
+    const newEntity = Object.assign(entity, { id: newId });
     entityData.push(newEntity);
     return newEntity;
 };

--- a/src/resolver/Mutation/create.js
+++ b/src/resolver/Mutation/create.js
@@ -1,6 +1,6 @@
 export default (entityData = []) => (_, entity) => {
     const newId =
-        entityData.length > 0 ? entityData[entityData.length - 1].id + 1 : 1;
+        entityData.length > 0 ? entityData[entityData.length - 1].id + 1 : 0;
     const newEntity = Object.assign(entity, { id: newId });
     entityData.push(newEntity);
     return newEntity;

--- a/src/resolver/Mutation/create.js
+++ b/src/resolver/Mutation/create.js
@@ -1,7 +1,7 @@
 export default (entityData = []) => (_, entity) => {
     const newId =
         entityData.length > 0 ? entityData[entityData.length - 1].id + 1 : 0;
-    const newEntity = Object.assign(entity, { id: newId });
+    const newEntity = Object.assign({}, entity, { id: newId });
     entityData.push(newEntity);
     return newEntity;
 };

--- a/src/resolver/Mutation/create.spec.js
+++ b/src/resolver/Mutation/create.spec.js
@@ -1,7 +1,7 @@
 import create from './create';
 
-test('returns a new object with id 0 on empty datastore', () => {
-    expect(create()(null, {})).toEqual({ id: 0 });
+test('returns a new object with id 1 on empty datastore', () => {
+    expect(create()(null, {})).toEqual({ id: 1 });
 });
 
 test('returns a new object with incremental id', () => {

--- a/src/resolver/Mutation/create.spec.js
+++ b/src/resolver/Mutation/create.spec.js
@@ -1,7 +1,7 @@
 import create from './create';
 
-test('returns a new object with id 1 on empty datastore', () => {
-    expect(create()(null, {})).toEqual({ id: 1 });
+test('returns a new object with id 0 on empty datastore', () => {
+    expect(create()(null, {})).toEqual({ id: 0 });
 });
 
 test('returns a new object with incremental id', () => {


### PR DESCRIPTION
## Description
- Fix issue with Create function not incrementing the id and just use the passed id.
- Fix issue with Remove function using Boolean return type but it actually uses the Type's name.

<!--- Describe your changes in detail -->
- Existing `remove`Typename has a return type of boolean but in reality it returns an object or undefined.
- Existing create function overrides the incremental id attribute and just use the id coming from the api.

## Related Issue
- https://github.com/marmelab/json-graphql-server/issues/43
- https://github.com/marmelab/json-graphql-server/issues/102
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->