### PR TITLE
Add hostname cli parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ json-graphql-server db.js
 ```
 
 To use a port other than 3000, you can run `json-graphql-server db.js --p <your port here>`
+To use a host other than localhost, you can run `json-graphql-server db.js --h <your port here>`
 
 Now you can query your data in graphql. For instance, to issue the following query:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ json-graphql-server db.js
 ```
 
 To use a port other than 3000, you can run `json-graphql-server db.js --p <your port here>`
-To use a host other than localhost, you can run `json-graphql-server db.js --h <your port here>`
+To use a host other than localhost, you can run `json-graphql-server db.js --h <your host here>`
 
 Now you can query your data in graphql. For instance, to issue the following query:
 

--- a/bin/json-graphql-server.js
+++ b/bin/json-graphql-server.js
@@ -8,6 +8,7 @@ var JsonGraphqlServer = require('../lib/json-graphql-server.node.min').default;
 var dataFilePath = process.argv.length > 2 ? process.argv[2] : './data.json';
 var data = require(path.join(process.cwd(), dataFilePath));
 var PORT = process.env.NODE_PORT || 3000;
+var HOST = process.env.NODE_HOST || 'localhost';
 var app = express();
 
 process.argv.forEach((arg, index) => {
@@ -15,12 +16,16 @@ process.argv.forEach((arg, index) => {
   if (arg === '--p' && process.argv.length > index + 1) {
     PORT = process.argv[index + 1];
   }
+
+  if (arg === '--h' && process.argv.length > index + 1) {
+    HOST = process.argv[index + 1];
+  }
 });
 
 app.use(cors());
 app.use('/', JsonGraphqlServer(data));
-app.listen(PORT);
-var msg = `GraphQL server running with your data at http://localhost:${PORT}/`;
+app.listen(PORT, HOST);
+var msg = `GraphQL server running with your data at http://${HOST}:${PORT}/`;
 console.log(msg); // eslint-disable-line no-console
 
 process.on('unhandledRejection', (reason, p) => {


### PR DESCRIPTION
## Description

Adds the ability to set the hostname the server runs on from the CLI.

This uses the --h argument (to match the --p already existing).

This allows running in docker, virtual machines and etc more easily.

## Related issue

There is no related issue.
