### PR TITLE
Export get plain schema, modify readme with example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,33 @@ graphql(schema, query).then(result => {
 
 Or available in the global scope when running on a client as `jsonSchemaBuilder`.
 
+## Plain Schema
+
+If you want to use another server type instead of the built in graphql express,
+like apollo-server or etc, you can expose the plain schema to be built into
+an executable schema (there may be version issues otherwise).
+
+This uses the export `getPlainSchema`.
+
+```js
+import {ApolloServer} from 'apollo-server';
+import {makeExecutableSchema} from '@graphql-tools/schema'; // or graphql-tools
+import {applyMiddleware} from 'graphql-middleware';
+import {getPlainSchema} from 'json-graphql-server';
+
+const data = { };
+const schema = applyMiddleware(
+  makeExecutableSchema(getPlainSchema(data), exampleMiddleware)
+);
+
+const server = new ApolloServer({
+  schema
+});
+
+server.listen({ port:3000 });
+
+```
+
 ## Deployment
 
 Deploy with Heroku or Next.js.

--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,6 @@
 import jsonGraphqlExpress from './jsonGraphqlExpress';
-import schemaBuilder from './schemaBuilder';
+import schemaBuilder, { getPlainSchema as plainSchema } from './schemaBuilder';
 
 export const jsonSchemaBuilder = schemaBuilder;
+export const getPlainSchema = plainSchema;
 export default jsonGraphqlExpress;

--- a/src/schemaBuilder.js
+++ b/src/schemaBuilder.js
@@ -53,3 +53,10 @@ export default (data) =>
         resolvers: resolver(data),
         logger: { log: (e) => console.log(e) }, // eslint-disable-line no-console
     });
+
+// Same as above, simply returning the object before making it executable.
+// This lets you use it with a custom apollo server or etc.
+export const getPlainSchema = (data) => ({
+    typeDefs: printSchema(getSchemaFromData(data)),
+    resolvers: resolver(data),
+});


### PR DESCRIPTION
## Description

Exposes the non-executable schema to be transformed by another version of graphql tools, in case you want to auto-generate test data for apollo-server or etc and also have graphql-middleware.

## Related Issue
No Related issue.