### PR TITLE
Import graphqlHTTP from express-graphql

### DIFF
--- a/src/jsonGraphqlExpress.js
+++ b/src/jsonGraphqlExpress.js
@@ -1,4 +1,4 @@
-import graphqlHTTP from 'express-graphql';
+import { graphqlHTTP } from 'express-graphql';
 import schemaBuilder from './schemaBuilder';
 
 /**


### PR DESCRIPTION
## Description

This library is a dependency of one of the example of [graphql-hooks](https://github.com/nearform/graphql-hooks). We ha a broken CI lately and discovered that it was related to a `TypeError: graphqlHTTP is not a function`

I don't understand why because the underlying `express-graphql` library didn't change lately.