### PR TITLE
Add ISO string Date support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,19 @@ For every field named `*_id`, json-graphql-server creates a two-way relationship
 
 The `all*` queries accept parameters to let you sort, paginate, and filter the list of results. You can filter by any field, not just the primary key. For instance, you can get the posts written by user `123`. Json-graphql-server also adds a full-text query field named `q`, and created range filter fields for numeric and date fields. All types (excluding booleans and arrays) get a not equal filter. The detail of all available filters can be seen in the generated `*Filter` type.
 
+### Supported types
+
+| Type    | GraphQL Type        | Rule                                                          | Example value |
+|---------|---------------------|---------------------------------------------------------------|---------------|
+| Id      | `GraphQLID`         | `name === 'id' \|\| name.substr(name.length - 3) === '_id'`     | `1`           |
+| Integer | `GraphQLInt`        | `Number.isInteger(value)`                                     | `12`          |
+| Numeric | `GraphQLFloat`      | `!isNaN(parseFloat(value)) && isFinite(value)`                | `12.34`       |
+| Boolean | `GraphQLBoolean`    | `typeof value === 'boolean'`                                  | `false`       |
+| String  | `GraphQLString`     | `typeof value === 'string'`                                   | `'foo'`       |
+| Array   | `GraphQLList`       | `Array.isArray(value)`                                        | `['bar']`, `[12, 34]` |
+| Date    | `DateType` (custom) | `value instanceof Date \|\| isISODateString(value)`             | `new Date('2016-06-10T15:49:14.236Z')`, `'2016-06-10T15:49:14.236Z'` |
+| Object  | `GraphQLJSON`       | `Object.prototype.toString.call(value) === '[object Object]'` | `transport: { service: 'fakemail', auth: { user: 'fake@mail.com', pass: 'f00b@r' } }` |
+
 ## GraphQL Usage
 
 Here is how you can use the queries and mutations generated for your data, using `Post` as an example:

--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ The `all*` queries accept parameters to let you sort, paginate, and filter the l
 
 | Type    | GraphQL Type        | Rule                                                          | Example value |
 |---------|---------------------|---------------------------------------------------------------|---------------|
-| Id      | `GraphQLID`         | `name === 'id' \|\| name.substr(name.length - 3) === '_id'`     | `1`           |
+| Id      | `GraphQLID`         | `name === 'id' \|\| name.substr(name.length - 3) === '_id'`   | `1`           |
 | Integer | `GraphQLInt`        | `Number.isInteger(value)`                                     | `12`          |
 | Numeric | `GraphQLFloat`      | `!isNaN(parseFloat(value)) && isFinite(value)`                | `12.34`       |
 | Boolean | `GraphQLBoolean`    | `typeof value === 'boolean'`                                  | `false`       |
 | String  | `GraphQLString`     | `typeof value === 'string'`                                   | `'foo'`       |
 | Array   | `GraphQLList`       | `Array.isArray(value)`                                        | `['bar']`, `[12, 34]` |
-| Date    | `DateType` (custom) | `value instanceof Date \|\| isISODateString(value)`             | `new Date('2016-06-10T15:49:14.236Z')`, `'2016-06-10T15:49:14.236Z'` |
+| Date    | `DateType` (custom) | `value instanceof Date \|\| isISODateString(value)`           | `new Date('2016-06-10T15:49:14.236Z')`, `'2016-06-10T15:49:14.236Z'` |
 | Object  | `GraphQLJSON`       | `Object.prototype.toString.call(value) === '[object Object]'` | `transport: { service: 'fakemail', auth: { user: 'fake@mail.com', pass: 'f00b@r' } }` |
 
 ## GraphQL Usage

--- a/src/introspection/DateType.js
+++ b/src/introspection/DateType.js
@@ -1,6 +1,13 @@
 import { GraphQLScalarType, GraphQLError } from 'graphql';
 import { Kind } from 'graphql/language';
 
+export const isISODateString = (value) => {
+    if (typeof value !== 'string') return false;
+    if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(value)) return false;
+    const d = new Date(value);
+    return d.toISOString() === value;
+};
+
 export default new GraphQLScalarType({
     name: 'Date',
     description: 'Date type',
@@ -10,6 +17,7 @@ export default new GraphQLScalarType({
     },
     serialize(value) {
         // value comes from resolvers
+        if (isISODateString(value)) return value;
         return value.toISOString(); // sent to the client
     },
     parseLiteral(ast) {

--- a/src/introspection/DateType.js
+++ b/src/introspection/DateType.js
@@ -1,9 +1,11 @@
 import { GraphQLScalarType, GraphQLError } from 'graphql';
 import { Kind } from 'graphql/language';
 
+const ISO_DATE_STRING_PATTERN = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
+
 export const isISODateString = (value) => {
     if (typeof value !== 'string') return false;
-    if (!/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/.test(value)) return false;
+    if (!ISO_DATE_STRING_PATTERN.test(value)) return false;
     const d = new Date(value);
     return d.toISOString() === value;
 };

--- a/src/introspection/getTypeFromValues.js
+++ b/src/introspection/getTypeFromValues.js
@@ -8,7 +8,7 @@ import {
     GraphQLString,
 } from 'graphql';
 import GraphQLJSON from 'graphql-type-json';
-import DateType from './DateType';
+import DateType, { isISODateString } from './DateType';
 
 const isNumeric = (value) => !isNaN(parseFloat(value)) && isFinite(value);
 const valuesAreNumeric = (values) => values.every(isNumeric);
@@ -20,7 +20,7 @@ const isString = (value) => typeof value === 'string';
 const valuesAreString = (values) => values.every(isString);
 const isArray = (value) => Array.isArray(value);
 const valuesAreArray = (values) => values.every(isArray);
-const isDate = (value) => value instanceof Date;
+const isDate = (value) => value instanceof Date || isISODateString(value);
 const valuesAreDate = (values) => values.every(isDate);
 const isObject = (value) =>
     Object.prototype.toString.call(value) === '[object Object]';

--- a/src/introspection/getTypeFromValues.spec.js
+++ b/src/introspection/getTypeFromValues.spec.js
@@ -60,6 +60,13 @@ test('returns DateType for Dates', () =>
     expect(
         getTypeFromValues('foo', [new Date('2017-03-15'), new Date()])
     ).toEqual(DateType));
+test('returns DateType for Dates as ISO Strings', () =>
+    expect(
+        getTypeFromValues('foo', [
+            '2022-01-01T00:00:00.000Z',
+            '2022-12-01T12:34:56.000Z',
+        ])
+    ).toEqual(DateType));
 
 test('returns GraphQLJSON for objects', () =>
     expect(


### PR DESCRIPTION
## Description

Add ISO string Date support

For example:

```json
{"posts": [
   {
       "id": "test",
       "postTime": "2022-01-01T00:00:00Z"
   }
]}
```

Supersedes #138 

## Related Issue

Fixes #136 

## ToDo

- [x] Detect type as Date
- [x] Handle ISO string date correctly in custom `DateType`
- [x] Add list of supported types in doc
- [x] Rebase onto #138 
