### PR TITLE
Fix createMany Input Type requiring an id

### DIFF
--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -143,9 +143,9 @@ export default (data) => {
             const { id, ...createFields } = typeFields;
 
             // Build input type.
-            const inputFields = Object.keys(typeFields).reduce(
+            const inputFields = Object.keys(createFields).reduce(
                 (f, fieldName) => {
-                    f[fieldName] = Object.assign({}, typeFields[fieldName]);
+                    f[fieldName] = Object.assign({}, createFields[fieldName]);
                     delete f[fieldName].resolve;
                     return f;
                 },

--- a/src/introspection/getSchemaFromData.spec.js
+++ b/src/introspection/getSchemaFromData.spec.js
@@ -265,6 +265,38 @@ test('creates three mutation fields per data type', () => {
     ]);
 });
 
+test('creates the mutation *Input type for createMany', () => {
+    const mutations = getSchemaFromData(data).getMutationType().getFields();
+    const createManyPostInputType = mutations['createManyPost'].args[0].type;
+    expect(createManyPostInputType.toString()).toEqual('[PostInput]');
+    expect(createManyPostInputType.ofType.getFields()).toEqual({
+        title: {
+            type: new GraphQLNonNull(GraphQLString),
+            name: 'title',
+            astNode: undefined,
+            defaultValue: undefined,
+            description: undefined,
+            extensions: undefined,
+        },
+        views: {
+            type: new GraphQLNonNull(GraphQLInt),
+            name: 'views',
+            astNode: undefined,
+            defaultValue: undefined,
+            description: undefined,
+            extensions: undefined,
+        },
+        user_id: {
+            type: new GraphQLNonNull(GraphQLID),
+            name: 'user_id',
+            astNode: undefined,
+            defaultValue: undefined,
+            description: undefined,
+            extensions: undefined,
+        },
+    });
+});
+
 test('pluralizes and capitalizes correctly', () => {
     const data = {
         feet: [


### PR DESCRIPTION
## Description

Removes the `id` field from the `*Input` type (used only for the **createMany** mutation).

## Related Issue

Fixes https://github.com/marmelab/json-graphql-server/issues/132

## ToDo

- [x] Fix createMany Input Type requiring an id although it is generated
