### PR TITLE
Fix CLI parameters short name

### DIFF
--- a/bin/json-graphql-server.js
+++ b/bin/json-graphql-server.js
@@ -13,7 +13,7 @@ var app = express();
 
 process.argv.forEach((arg, index) => {
     // allow a custom port via CLI
-    if ((arg === '--p' || arg === '--port') && process.argv.length > index + 1) {
+    if ((arg === '-p' || arg === '--port') && process.argv.length > index + 1) {
         PORT = process.argv[index + 1];
     }
 

--- a/bin/json-graphql-server.js
+++ b/bin/json-graphql-server.js
@@ -17,7 +17,7 @@ process.argv.forEach((arg, index) => {
         PORT = process.argv[index + 1];
     }
 
-    if ((arg === '--h' || arg === '--host') && process.argv.length > index + 1) {
+    if ((arg === '-h' || arg === '--host') && process.argv.length > index + 1) {
         HOST = process.argv[index + 1];
     }
 });

--- a/bin/json-graphql-server.js
+++ b/bin/json-graphql-server.js
@@ -13,11 +13,11 @@ var app = express();
 
 process.argv.forEach((arg, index) => {
     // allow a custom port via CLI
-    if ((arg === '-p' || arg === '--port') && process.argv.length > index + 1) {
+    if ((arg === '--p' || arg === '--port') && process.argv.length > index + 1) {
         PORT = process.argv[index + 1];
     }
 
-    if ((arg === '--h'|| arg === '--host') && process.argv.length > index + 1) {
+    if ((arg === '--h' || arg === '--host') && process.argv.length > index + 1) {
         HOST = process.argv[index + 1];
     }
 });


### PR DESCRIPTION
~Originally, I was not able to run the JSON GraphQL server at port 5000 with `-p 5000`.~

~On this branch, you can now run the the command `./bin/json-graphql-server db.js -p 5000` or  `./bin/json-graphql-server db.js --port 5000`~

This PR fixes an inconsistency between the `--host` and `--port` parameters of the CLI, which short names should be `-h` and `-p` respectively. This is also what's documented in the Readme.