### PR TITLE
fix: point GraphiQL handler to correct server path

### DIFF
--- a/src/graphiqlHandler.js
+++ b/src/graphiqlHandler.js
@@ -4,7 +4,7 @@ export const graphiqlHandler = (req, res) => {
     });
     return res.end(
         getGraphiqlHtml({
-            endpoint: '/',
+            endpoint: '/graphql',
         })
     );
 };
@@ -71,7 +71,6 @@ const getGraphiqlHtml = ({ endpoint }) => `
       const root = ReactDOM.createRoot(document.getElementById('graphiql'));
       const fetcher = GraphiQL.createFetcher({
         url: '${endpoint}',
-        headers: { 'X-Example-Header': 'foo' },
       });
       const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
       root.render(


### PR DESCRIPTION
## Description

Point `GraphiQL` handler to correct path as mentioned in docs. 

- Update path
- Remove unnecessary request header

## Related Issue

See #179 for more details.

