### PR TITLE
Add support for deleteXXX in addition to removeXXX

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ type Mutation {
   createPost(data: String): Post
   createManyPost(data: [{data:String}]): [Post]
   updatePost(data: String): Post
-  removePost(id: ID!): Post
+  deletePost(id: ID!): Post
 }
 type Post {
     id: ID!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "json-graphql-server",
-    "version": "3.1.2",
+    "version": "3.2.0",
     "type": "module",
     "main": "./dist/json-graphql-server.cjs",
     "module": "./dist/json-graphql-server.js",
@@ -72,5 +72,6 @@
     },
     "bin": {
         "json-graphql-server": "bin/json-graphql-server.cjs"
-    }
+    },
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/introspection/getSchemaFromData.js
+++ b/src/introspection/getSchemaFromData.js
@@ -179,6 +179,12 @@ export default (data) => {
                     id: { type: new GraphQLNonNull(GraphQLID) },
                 },
             };
+            fields[`delete${type.name}`] = {
+                type: typesByName[type.name],
+                args: {
+                    id: { type: new GraphQLNonNull(GraphQLID) },
+                },
+            };
             return fields;
         }, {}),
     });

--- a/src/introspection/getSchemaFromData.spec.js
+++ b/src/introspection/getSchemaFromData.spec.js
@@ -211,6 +211,13 @@ test('creates three mutation fields per data type', () => {
             type: new GraphQLNonNull(GraphQLID),
         }),
     ]);
+    expect(mutations['deletePost'].type.name).toEqual(PostType.name);
+    expect(mutations['deletePost'].args).toEqual([
+        expect.objectContaining({
+            name: 'id',
+            type: new GraphQLNonNull(GraphQLID),
+        }),
+    ]);
     expect(mutations['createUser'].type.name).toEqual(UserType.name);
     expect(mutations['createUser'].args).toEqual([
         expect.objectContaining({
@@ -231,6 +238,13 @@ test('creates three mutation fields per data type', () => {
     ]);
     expect(mutations['removeUser'].type.name).toEqual(UserType.name);
     expect(mutations['removeUser'].args).toEqual([
+        expect.objectContaining({
+            name: 'id',
+            type: new GraphQLNonNull(GraphQLID),
+        }),
+    ]);
+    expect(mutations['deleteUser'].type.name).toEqual(UserType.name);
+    expect(mutations['deleteUser'].args).toEqual([
         expect.objectContaining({
             name: 'id',
             type: new GraphQLNonNull(GraphQLID),

--- a/src/resolver/index.js
+++ b/src/resolver/index.js
@@ -24,6 +24,7 @@ const getMutationResolvers = (entityName, data) => ({
     [`createMany${entityName}`]: createMany(data),
     [`update${entityName}`]: update(data),
     [`remove${entityName}`]: remove(data),
+    [`delete${entityName}`]: remove(data),
 });
 
 export default (data) => {


### PR DESCRIPTION
## Description

Make the integration with `ra-graphql-data-simple` simpler.
Support both `removeXXX` and `deleteXXX` to avoid breaking changes.

## Related Issue

See https://github.com/marmelab/react-admin/issues/4431

