### PR TITLE
Replace UNPKG in generated HTML w/ jsDelivr

### DIFF
--- a/src/graphiqlHandler.ts
+++ b/src/graphiqlHandler.ts
@@ -37,11 +37,11 @@ const getGraphiqlHtml = ({ endpoint }: { endpoint: string }) => `
     </style>
     <script
       crossorigin
-      src="https://unpkg.com/react@18/umd/react.production.min.js"
+      src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"
+      src="https://cdn.jsdelivr.net/npm/react-dom@18/umd/react-dom.production.min.js"
     ></script>
     <!--
       These two files can be found in the npm module, however you may wish to
@@ -49,21 +49,21 @@ const getGraphiqlHtml = ({ endpoint }: { endpoint: string }) => `
       favored resource bundler.
      -->
     <script
-      src="https://unpkg.com/graphiql/graphiql.min.js"
+      src="https://cdn.jsdelivr.net/npm/graphiql/graphiql.min.js"
       type="application/javascript"
     ></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphiql/graphiql.min.css" />
     <!-- 
       These are imports for the GraphIQL Explorer plugin.
      -->
     <script
-      src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js"
+      src="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer/dist/index.umd.js"
       crossorigin
     ></script>
 
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css"
+      href="https://cdn.jsdelivr.net/npm/@graphiql/plugin-explorer/dist/style.css"
     />
   </head>
 


### PR DESCRIPTION
## Description

UNPKG has not been actively maintained and has been down since `Mar 15, 2025` (https://github.com/unpkg/unpkg/issues/412).

The PR replaces UNPKG in the HTML tamplate with jsDelivr.

## Related Issue

https://github.com/unpkg/unpkg/issues/412
https://github.com/unpkg/unpkg/issues/413
https://github.com/unpkg/unpkg/issues/414
https://github.com/unpkg/unpkg/issues/416