### PR TITLE
Fix `make install` command to also properly install `node` example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 
 install: package.json ## Install dependencies
 	@$(PKG) install
+	@cd example/node && $(PKG) install
 
 watch: ## continuously compile ES6 files to JS
 	@yarn vite build --watch

--- a/example/node/yarn.lock
+++ b/example/node/yarn.lock
@@ -547,7 +547,7 @@ is-promise@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 json-graphql-server@../../:
-  version "3.2.1"
+  version "3.3.0"
   dependencies:
     "@apollo/client" "^3.12.11"
     "@graphql-tools/schema" "^10.0.18"
@@ -559,9 +559,6 @@ json-graphql-server@../../:
     inflection "^3.0.2"
     lodash.merge "^4.6.2"
     xhr-mock "^2.5.1"
-
-"json-graphql-server@file:..":
-  version "0.0.0"
 
 lodash.merge@^4.6.2:
   version "4.6.2"


### PR DESCRIPTION
## Description

Following https://github.com/marmelab/json-graphql-server/pull/199 a TS example was introduced in the `node` folder. However this example package was not properly installed when running `make install`, leading to unexpected behaviors.

This PR fixes the `make install` script.
